### PR TITLE
output and error file locations are configurable via cluster.json

### DIFF
--- a/{{cookiecutter.profile_name}}/pbs-submit.py
+++ b/{{cookiecutter.profile_name}}/pbs-submit.py
@@ -136,6 +136,15 @@ if walltime and (nodes or mem): resourceparams = resourceparams + ","
 if walltime: resourceparams = resourceparams + walltime
 if nodes or mem or walltime: resourceparams = resourceparams + "\""
 
+if "cluster" in job_properties:
+    cluster = job_properties["cluster"]
+    if "error" in cluster:
+        os.makedirs(os.path.dirname(cluster["error"]), exist_ok=True)
+        se = " -e " + cluster["error"]
+    if "output" in cluster:
+        os.makedirs(os.path.dirname(cluster["output"]), exist_ok=True)
+        so = " -o " + cluster["output"]
+
 cmd = "qsub {a}{A}{b}{c}{C}{d}{D}{e}{f}{h}{j}{l}{m}{M}{N}{o}{p}{P}{q}{t}{u}{v}{V}{w}{W}{rp}{dep}{ex}".format(\
 	a=atime,A=acc_string,b=pbs_time,c=chkpt,C=pref,d=dd,D=rd,e=se,f=ft,h=hold,j=j,l=resource,m=mail,M=mailuser,\
 	N=jname,o=so,p=priority,P=proxy,q=q,t=ar,u=user,v=ev,V=eall,w=wd,W=add,rp=resourceparams,dep=depend,ex=extras)


### PR DESCRIPTION
The location of cluster output end error logs can be configured by the user through the "output" and "error" fields in cluster.json. 

This feature already exists in  [slurm profile](https://github.com/Snakemake-Profiles/slurm), but this approach is slightly different than setting location through cookiecutter, because unless user generates a new profile for each project, that enforces the same location for cluster logs for all projects. I think cluster.json is a better place to set this.